### PR TITLE
remove github ref type checking on push

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pushed modules are created with the Git commit SHA as the module tag.
 Here's an example usage of `buf-push-action`:
 
 ```yaml
-on: pull_request # Apply to all pull requests
+on: push # Apply to all push
 jobs:
   push-module:
     # Run `git checkout`
@@ -25,7 +25,7 @@ jobs:
         draft: ${{ github.ref_name != 'main'}}
 ```
 
-With this configuration, upon a pull request [opened, synchronize, or reopened][github-workflow]
+With this configuration, upon a push [branches, tags][github-workflow]
 the `buf` CLI pushes the [configured module][buf-yaml] to the BSR using the provided to
 authenticate the request. When the triggering branch is not `main`, the commit will be pushed
 as a [draft][buf-draft].
@@ -167,7 +167,7 @@ jobs:
 [buf-yaml]: https://docs.buf.build/configuration/v1/buf-yaml
 [github-secret]: https://docs.github.com/en/actions/reference/encrypted-secrets
 [github-token]: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
-[github-workflow]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+[github-workflow]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
 [input]: https://docs.buf.build/reference/inputs
 [lint]: https://docs.buf.build/lint
 [modules]: https://docs.buf.build/bsr/overview#module

--- a/push.bash
+++ b/push.bash
@@ -25,10 +25,6 @@ if [ -z "${GITHUB_REF_NAME}" ]; then
   fail "the commit ref was not provided"
 fi
 
-if [ -z "${GITHUB_REF_TYPE}" ]; then
-  fail "the commit ref type was not provided"
-fi
-
 if [ -z "${BUF_TOKEN}" ]; then
   fail "a buf authentication token was not provided"
 fi
@@ -39,11 +35,6 @@ BUF_COMMAND="$(type -P buf)" || fail "$NOT_INSTALLED_MESSAGE"
 
 if [ -z "$BUF_COMMAND" ]; then
   fail "$NOT_INSTALLED_MESSAGE"
-fi
-
-if [ "${GITHUB_REF_TYPE}" != "branch" ]; then
-  echo "reference type is not branch, skipping" >&2
-  exit 0
 fi
 
 BUF_ARGS=("--tag" "${GITHUB_SHA}")

--- a/test/test.bash
+++ b/test/test.bash
@@ -13,11 +13,11 @@ PATH="${DIR}/tmp/test/bin:$PATH"
 cp test/buf.bash tmp/test/bin/buf
 chmod +x tmp/test/bin/buf
 
-# prevent the GITHUB_SHA, GITHUB_REF_NAME and GITHUB_REF_TYPE set by actions from being used in test
-unset GITHUB_SHA GITHUB_REF_NAME GITHUB_REF_TYPE
+# prevent the GITHUB_SHA and GITHUB_REF_NAME set by actions from being used in test
+unset GITHUB_SHA GITHUB_REF_NAME
 
 test_push() {
-  export GITHUB_SHA GITHUB_REF_NAME GITHUB_REF_TYPE BUF_TOKEN DRAFT WANT_BUF_TOKEN WANT_ARGS
+  export GITHUB_SHA GITHUB_REF_NAME BUF_TOKEN DRAFT WANT_BUF_TOKEN WANT_ARGS
   set +e
   ./push.bash "$@" > tmp/test/stdout 2> tmp/test/stderr
   GOT_EXIT_CODE="${?}"
@@ -39,13 +39,12 @@ test_push() {
     fi
   fi
   rm -f tmp/test/stdout tmp/test/stderr
-  unset GITHUB_SHA GITHUB_REF_NAME GITHUB_REF_TYPE BUF_TOKEN WANT_BUF_TOKEN WANT_ARGS
+  unset GITHUB_SHA GITHUB_REF_NAME BUF_TOKEN WANT_BUF_TOKEN WANT_ARGS
 }
 
 echo "testing happy path"
 GITHUB_SHA=fake-sha
 GITHUB_REF_NAME=main
-GITHUB_REF_TYPE=branch
 BUF_TOKEN=fake-token
 WANT_BUF_TOKEN=fake-token
 WANT_ARGS="push some/input/path --tag fake-sha"
@@ -58,7 +57,6 @@ echo "ok"
 echo "testing happy path draft"
 GITHUB_SHA=fake-sha
 GITHUB_REF_NAME=fake-ref
-GITHUB_REF_TYPE=branch
 BUF_TOKEN=fake-token
 DRAFT=true
 WANT_BUF_TOKEN=fake-token
@@ -72,7 +70,6 @@ echo "ok"
 echo "testing happy path draft on main branch"
 GITHUB_SHA=fake-sha
 GITHUB_REF_NAME=main
-GITHUB_REF_TYPE=branch
 BUF_TOKEN=fake-token
 DRAFT=true
 WANT_BUF_TOKEN=fake-token
@@ -86,7 +83,6 @@ echo "ok"
 echo "testing no input"
 GITHUB_SHA=fake-sha
 GITHUB_REF_NAME=main
-GITHUB_REF_TYPE=branch
 BUF_TOKEN=fake-token
 WANT_STDOUT=""
 WANT_STDERR="Usage: ./push.bash <input>"
@@ -106,7 +102,6 @@ echo "ok"
 echo "testing no BUF_TOKEN"
 GITHUB_SHA=fake-sha
 GITHUB_REF_NAME=main
-GITHUB_REF_TYPE=branch
 WANT_STDOUT='::add-mask::
 ::error::a buf authentication token was not provided'
 WANT_STDERR=""


### PR DESCRIPTION
fixes #26

This remove the checking of `GITHUB_REF_TYPE` environment variable equals to `branch` in the action, which was added to support draft. Also updated the readme example which is more aligned with the flow we suggest.

My original thought for this fix was to put the checking inside the block of `if [ "${DRAFT}" == "true" ]; then` so that its only check when it is expected to be a draft, but after thinking about this more it doesn't seems to be a necessary check for draft neither (or at least not something we should block for the user), as user might also want to only push as draft when pushing a git tag, so decided to just remove the `GITHUB_REF_TYPE` checking.

tested with an action condition of
```
on:
  push:
    tags:
      - push-to-bsr
```
and its working as expected (push to bsr `main` when adding a tag `push-to-bsr`)



