### PR TITLE
Support creating repos if not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ jobs:
     - uses: bufbuild/buf-push-action@v1
       with:
         buf_token: ${{ secrets.BUF_TOKEN }}
+        create_visibility: private
         draft: ${{ github.ref_name != 'main'}}
 ```
 
 With this configuration, upon a push [branches, tags][github-workflow]
 the `buf` CLI pushes the [configured module][buf-yaml] to the BSR using the provided to
-authenticate the request. When the triggering branch is not `main`, the commit will be pushed
+authenticate the request. If the repository does not already exist on the BSR, create it
+with private visibility. When the triggering branch is not `main`, the commit will be pushed
 as a [draft][buf-draft].
 
 For instructions on creating a BSR API token, see our [official docs][bsr-token]. Once you've
@@ -41,11 +43,12 @@ We recommend using [`buf-setup-action`][buf-setup] to install it (as in the exam
 
 ## Configuration
 
-| Parameter   | Description                                                                    | Required | Default                             |
-|:------------|:-------------------------------------------------------------------------------|:---------|:------------------------------------|
-| `buf_token` | The [Buf authentication token][buf-token] used for private [Buf inputs][input] | ✅        | [`${{github.token}}`][github-token] |
-| `input`     | The path of the [input] you want to push to BSR as a module                    |          | `.`                                 |
-| `draft`     | Indicates if the workflows should push to the BSR as a [draft][buf-draft]      |          |                                     |
+| Parameter           | Description                                                                    | Required | Default                             |
+| :------------------ | :----------------------------------------------------------------------------- | :------- | :---------------------------------- |
+| `buf_token`         | The [Buf authentication token][buf-token] used for private [Buf inputs][input] | ✅       | [`${{github.token}}`][github-token] |
+| `input`             | The path of the [input] you want to push to BSR as a module                    |          | `.`                                 |
+| `draft`             | Indicates if the workflows should push to the BSR as a [draft][buf-draft]      |          |                                     |
+| `create_visibility` | The visibility to create the BSR repository with, if it does not already exist |          |                                     |
 
 > These parameters are derived from [`action.yml`](./action.yml).
 

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,13 @@ inputs:
     required: true
   input:
     description: The Input path.
-    default: '.'
+    default: "."
     required: false
   draft:
     description: The identifier of pushing to the BSR as a draft commit, when set to 'true' the action will push the module as draft with the branch name as draft name.
+    required: false
+  create_visibility:
+    description: The visibility of the BSR repository to be created with, if one needs to be created.
     required: false
 runs:
   using: composite
@@ -23,4 +26,5 @@ runs:
       env:
         BUF_TOKEN: ${{ inputs.buf_token }}
         DRAFT: ${{ inputs.draft }}
+        CREATE_VISIBILITY: ${{ create_visibility }}
       run: $GITHUB_ACTION_PATH/push.bash ${{ inputs.input }}

--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ runs:
       env:
         BUF_TOKEN: ${{ inputs.buf_token }}
         DRAFT: ${{ inputs.draft }}
-        CREATE_VISIBILITY: ${{ create_visibility }}
+        CREATE_VISIBILITY: ${{ inputs.create_visibility }}
       run: $GITHUB_ACTION_PATH/push.bash ${{ inputs.input }}

--- a/push.bash
+++ b/push.bash
@@ -51,4 +51,17 @@ if [ "${DRAFT}" == "true" ]; then
   BUF_ARGS=("--draft" "${GITHUB_REF_NAME}")
 fi
 
+if [ -n "${CREATE_VISIBILITY}"]; then
+  set +e
+  BUF_HELP_OUTPUT="$("${BUF_COMMAND}" push example --create --help 2>&1)" # need to verify this
+  set -e
+  if [[ "${BUF_HELP_OUTPUT}" == *"unknown flag: --create"* ]]; then
+    fail "The installed version of buf does not support creating repositories. Please use buf v1.19.0 or newer." # TODO: check if it's in 1.19.0 when it's released
+  fi
+  if [[ "${CREATE_VISIBILITY}" != "public" && "${CREATE_VISIBILITY}" != "private" ]]; then
+    fail "Must specify --create-visibility as either 'public' or 'private'"
+  fi
+  BUF_ARGS+=("--create" "--create-visibility" "${CREATE_VISIBILITY}")
+fi
+
 BUF_TOKEN="${BUF_TOKEN}" "${BUF_COMMAND}" "push" "${BUF_INPUT}" "${BUF_ARGS[@]}"

--- a/push.bash
+++ b/push.bash
@@ -51,7 +51,7 @@ if [ "${DRAFT}" == "true" ]; then
   BUF_ARGS=("--draft" "${GITHUB_REF_NAME}")
 fi
 
-if [ -n "${CREATE_VISIBILITY}"]; then
+if [ -n "${CREATE_VISIBILITY}" ]; then
   set +e
   BUF_HELP_OUTPUT="$("${BUF_COMMAND}" push example --create --help 2>&1)" # need to verify this
   set -e

--- a/push.bash
+++ b/push.bash
@@ -56,7 +56,7 @@ if [ -n "${CREATE_VISIBILITY}" ]; then
   BUF_HELP_OUTPUT="$("${BUF_COMMAND}" push example --create --help 2>&1)" # need to verify this
   set -e
   if [[ "${BUF_HELP_OUTPUT}" == *"unknown flag: --create"* ]]; then
-    fail "The installed version of buf does not support creating repositories. Please use buf v1.19.0 or newer." # TODO: check if it's in 1.19.0 when it's released
+    fail "The installed version of buf does not support creating repositories. Please use buf v1.19.0 or newer."
   fi
   if [[ "${CREATE_VISIBILITY}" != "public" && "${CREATE_VISIBILITY}" != "private" ]]; then
     fail "Must specify --create-visibility as either 'public' or 'private'"

--- a/push.bash
+++ b/push.bash
@@ -56,7 +56,7 @@ if [ -n "${CREATE_VISIBILITY}" ]; then
   BUF_HELP_OUTPUT="$("${BUF_COMMAND}" push example --create --help 2>&1)"
   set -e
   if [[ "${BUF_HELP_OUTPUT}" == *"unknown flag: --create"* ]]; then
-    fail "The installed version of buf does not support creating repositories. Please use buf v1.19.0 or newer."
+    fail "The installed version of buf does not support creating repositories on push. Please use buf v1.19.0 or newer."
   fi
   BUF_ARGS+=("--create" "--create-visibility" "${CREATE_VISIBILITY}")
 fi

--- a/push.bash
+++ b/push.bash
@@ -53,7 +53,7 @@ fi
 
 if [ -n "${CREATE_VISIBILITY}" ]; then
   set +e
-  BUF_HELP_OUTPUT="$("${BUF_COMMAND}" push example --create --help 2>&1)" # need to verify this
+  BUF_HELP_OUTPUT="$("${BUF_COMMAND}" push example --create --help 2>&1)"
   set -e
   if [[ "${BUF_HELP_OUTPUT}" == *"unknown flag: --create"* ]]; then
     fail "The installed version of buf does not support creating repositories. Please use buf v1.19.0 or newer."

--- a/push.bash
+++ b/push.bash
@@ -58,9 +58,6 @@ if [ -n "${CREATE_VISIBILITY}" ]; then
   if [[ "${BUF_HELP_OUTPUT}" == *"unknown flag: --create"* ]]; then
     fail "The installed version of buf does not support creating repositories. Please use buf v1.19.0 or newer."
   fi
-  if [[ "${CREATE_VISIBILITY}" != "public" && "${CREATE_VISIBILITY}" != "private" ]]; then
-    fail "Must specify --create-visibility as either 'public' or 'private'"
-  fi
   BUF_ARGS+=("--create" "--create-visibility" "${CREATE_VISIBILITY}")
 fi
 

--- a/test/test.bash
+++ b/test/test.bash
@@ -17,7 +17,7 @@ chmod +x tmp/test/bin/buf
 unset GITHUB_SHA GITHUB_REF_NAME
 
 test_push() {
-  export GITHUB_SHA GITHUB_REF_NAME BUF_TOKEN DRAFT WANT_BUF_TOKEN WANT_ARGS
+  export GITHUB_SHA GITHUB_REF_NAME BUF_TOKEN DRAFT WANT_BUF_TOKEN WANT_ARGS WANT_STDOUT WANT_STDERR WANT_EXIT_CODE CREATE_VISIBILITY
   set +e
   ./push.bash "$@" > tmp/test/stdout 2> tmp/test/stderr
   GOT_EXIT_CODE="${?}"
@@ -39,7 +39,7 @@ test_push() {
     fi
   fi
   rm -f tmp/test/stdout tmp/test/stderr
-  unset GITHUB_SHA GITHUB_REF_NAME BUF_TOKEN WANT_BUF_TOKEN WANT_ARGS
+  unset GITHUB_SHA GITHUB_REF_NAME BUF_TOKEN DRAFT WANT_BUF_TOKEN WANT_ARGS WANT_STDOUT WANT_STDERR WANT_EXIT_CODE CREATE_VISIBILITY
 }
 
 echo "testing happy path"
@@ -64,6 +64,20 @@ WANT_ARGS="push some/input/path --draft fake-ref"
 WANT_STDOUT="::add-mask::fake-token"
 WANT_STDERR=""
 WANT_EXIT_CODE=0
+test_push some/input/path
+echo "ok"
+
+echo "testing happy path create"
+GITHUB_SHA=fake-sha
+GITHUB_REF_NAME=main
+BUF_TOKEN=fake-token
+CREATE_VISIBILITY=private
+WANT_BUF_TOKEN=fake-token
+WANT_ARGS="push some/input/path --tag fake-sha --create --create-visibility private"
+WANT_STDOUT="::add-mask::fake-token"
+WANT_STDERR=""
+WANT_EXIT_CODE=0
+echo "CREATE is ${CREATE_VISIBILITY}"
 test_push some/input/path
 echo "ok"
 


### PR DESCRIPTION
Add optional key `create_visibility` to action, specifying it adds `--create --create-visibility` to `buf generate` invocation.

Note that CLI requires both `--create` and `--create-visibility`, whereas this action only requires `create_visibility`.

I prefer it this way because GitHub action error feedback loop is longer than the CLI. In an action, a user modifies the workflow file, commits it, pushes, waits for the action to run, checks result (a few clicks), sees an error. On the CLI, a user types on the command line and sees the result right away.

It is easier for the user to get it right on the first try if we only require one field.

I am also open to require `create` as well, for consistency with the CLI. 