### PR TITLE
Allow specifying `tag` parameter for setting a custom tag in BSR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,3 +40,12 @@ jobs:
         env:
           WANT_BUF_TOKEN: fake-buf-token
           WANT_ARGS: push path/to/input --draft ${{ github.ref_name }}
+      - name: run action with custom tag
+        uses: ./
+        with:
+          buf_token: fake-buf-token
+          input: path/to/input
+          tag: custom-tag
+        env:
+          WANT_BUF_TOKEN: fake-buf-token
+          WANT_ARGS: push path/to/input --tag custom-tag

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ We recommend using [`buf-setup-action`][buf-setup] to install it (as in the exam
 ## Configuration
 
 | Parameter           | Description                                                                    | Required | Default                             |
-| :------------------ | :----------------------------------------------------------------------------- | :------- | :---------------------------------- |
+| :------------------ |:-------------------------------------------------------------------------------| :------- | :---------------------------------- |
 | `buf_token`         | The [Buf authentication token][buf-token] used for private [Buf inputs][input] | ✅       | [`${{github.token}}`][github-token] |
 | `input`             | The path of the [input] you want to push to BSR as a module                    |          | `.`                                 |
 | `draft`             | Indicates if the workflows should push to the BSR as a [draft][buf-draft]      |          |                                     |
 | `create_visibility` | The visibility to create the BSR repository with, if it does not already exist |          |                                     |
+| `tag`               | The custom tag to push to the BSR                                              |          |                                     |
 
 > These parameters are derived from [`action.yml`](./action.yml).
 
@@ -128,6 +129,26 @@ run `buf mod update` so that the downstream module uses the upstream module's la
 is not supported by `buf-push-action` on its own - you'll need to stitch this functionality into
 your workflow on your own. For more details, see [this](https://github.com/bufbuild/buf/issues/838)
 discussion.
+
+### Push with a custom tag
+
+If you want to push a module with a tag other than the Git commit SHA (e.g. for using semantic
+versioning), you can set the `tag` property to the desired tag:
+
+```yaml
+steps:
+  # Run `git checkout`
+  - uses: actions/checkout@v2
+  # Install the `buf` CLI
+  - uses: bufbuild/buf-setup-action@v1
+  # Push only the Input in `proto` to the BSR
+  - uses: bufbuild/buf-push-action@v1
+    with:
+      input: proto
+      buf_token: ${{ secrets.BUF_TOKEN }}
+      # if triggered by a release tag, push with the tag
+      tag: ${{ github.ref_name }}
+```
 
 ### Validate before push
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   create_visibility:
     description: The visibility of the BSR repository to be created with, if one needs to be created.
     required: false
+  tag:
+    description: The tag to push the module as.
+    required: false
 runs:
   using: composite
   steps:
@@ -27,4 +30,5 @@ runs:
         BUF_TOKEN: ${{ inputs.buf_token }}
         DRAFT: ${{ inputs.draft }}
         CREATE_VISIBILITY: ${{ inputs.create_visibility }}
+        TAG: ${{ inputs.tag }}
       run: $GITHUB_ACTION_PATH/push.bash ${{ inputs.input }}

--- a/push.bash
+++ b/push.bash
@@ -37,7 +37,12 @@ if [ -z "$BUF_COMMAND" ]; then
   fail "$NOT_INSTALLED_MESSAGE"
 fi
 
-BUF_ARGS=("--tag" "${GITHUB_SHA}")
+VERSION=${GITHUB_SHA}
+if [ -n "${TAG}" ]; then
+  VERSION="${TAG}"
+fi
+
+BUF_ARGS=("--tag" "$VERSION")
 if [ "${DRAFT}" == "true" ]; then
   # Check that --draft is supported by running "buf push --draft example --help"
   # and checking for "unknown flag: --draft" in the output.

--- a/test/test.bash
+++ b/test/test.bash
@@ -17,7 +17,7 @@ chmod +x tmp/test/bin/buf
 unset GITHUB_SHA GITHUB_REF_NAME
 
 test_push() {
-  export GITHUB_SHA GITHUB_REF_NAME BUF_TOKEN DRAFT WANT_BUF_TOKEN WANT_ARGS WANT_STDOUT WANT_STDERR WANT_EXIT_CODE CREATE_VISIBILITY
+  export GITHUB_SHA GITHUB_REF_NAME TAG BUF_TOKEN DRAFT WANT_BUF_TOKEN WANT_ARGS WANT_STDOUT WANT_STDERR WANT_EXIT_CODE CREATE_VISIBILITY
   set +e
   ./push.bash "$@" > tmp/test/stdout 2> tmp/test/stderr
   GOT_EXIT_CODE="${?}"
@@ -120,5 +120,20 @@ WANT_STDOUT='::add-mask::
 ::error::a buf authentication token was not provided'
 WANT_STDERR=""
 WANT_EXIT_CODE=1
+test_push some/input/path
+echo "ok"
+
+echo "testing happy path create with tag"
+GITHUB_SHA=fake-sha
+TAG=fake-tag
+GITHUB_REF_NAME=main
+BUF_TOKEN=fake-token
+CREATE_VISIBILITY=private
+WANT_BUF_TOKEN=fake-token
+WANT_ARGS="push some/input/path --tag fake-tag --create --create-visibility private"
+WANT_STDOUT="::add-mask::fake-token"
+WANT_STDERR=""
+WANT_EXIT_CODE=0
+echo "TAG is ${TAG}"
 test_push some/input/path
 echo "ok"


### PR DESCRIPTION
Many users (including myself) would benefit from pushing semantic-versioned tags to the Buf Schema Registry for better versioning (for example, in a generated SDK).

This would resolve #20 